### PR TITLE
fix: prevent back-to-top button from overlapping

### DIFF
--- a/style.css
+++ b/style.css
@@ -773,13 +773,15 @@ footer {
   display: none; 
   position: fixed;
   bottom: 20px;
-  right: 30px;
+  right: 15px;
   z-index: 99;
   font-size: 18px;
   background-color: #444;
   color: white;
   border: none;
-  padding: 15px;
+  padding: 10px;
+  width: 45px;        
+  height: 45px;
   border-radius: 5px;
   cursor: pointer;
   transition: background-color 0.3s;
@@ -787,6 +789,7 @@ footer {
   box-shadow: 5px 0px 10px 0px rgba(227, 86, 5, 0.838),
     -0.1em 0 0.4em rgba(227, 86, 5, 0.838);
   transition: transform ease 0.5s, box-shadow ease 0.5s;
+   
 }
 
 /* Button hover effect */


### PR DESCRIPTION
## Description

This pull request fixes the misalignment issue of the "Go to Top" button, which was overlapping with the profile cards on the right side of the page. While the button was functional, its placement looked visually unappealing and inconsistent with the overall design.

Fixes: #[338] 



## Type of Change

- [ ] Profile Added
- [ ] Project Added
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify):

## How to Test

1. Open the profiles page.

2. Scroll down to make the Go-to-Top button  appear

**Verify that:**

The button no longer overlaps with the profile cards.

The new design looks properly aligned and visually consistent.



**BEFORE**
<img width="662" height="209" alt="image" src="https://github.com/user-attachments/assets/ca3b7f44-bdf2-4802-8e68-1b3cd6abff80" />



**AFTER**
<img width="664" height="231" alt="image" src="https://github.com/user-attachments/assets/46bb0b66-c040-43fc-925e-1c01eeeadb8b" />


## Checklist

- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [ ] I have made corresponding changes to the documentation (if applicable).  
- [x] My changes generate no new warnings.  
- [ ] I have added tests to cover my changes (if applicable).  
- [x] All new and existing tests pass.  


## Additional Notes

No additional notes from my side but if you have any additional improvements in mind do let me know.
