### PR TITLE
Added dark mode styles in the Contact Us form

### DIFF
--- a/style.css
+++ b/style.css
@@ -1243,3 +1243,32 @@ body:not(.light-background) .search-clear:hover {
 #searchInput:focus {
   animation: searchPulse 2s ease-in-out infinite;
 }
+
+/* Dark Mode Styles for Contact Section */
+body:not(.light-background) .contact-container {
+  background: var(--color-profile-card-bg);
+  box-shadow: 0 0 20px 25px rgba(51, 63, 70, 0.4);
+}
+
+body:not(.light-background) .contact-form-container {
+  background: var(--color-profile-card-bg);
+  color: var(--color-text);
+}
+
+body:not(.light-background) .contact-form input,
+body:not(.light-background) .contact-form textarea {
+  background-color: var(--color-body-bg);
+  color: var(--color-text);
+  border: 1px solid #333;
+}
+
+body:not(.light-background) .contact-form input::placeholder,
+body:not(.light-background) .contact-form textarea::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+body:not(.light-background) .contact-form input:focus,
+body:not(.light-background) .contact-form textarea:focus {
+  border-color: var(--color-profile-border);
+  box-shadow: 0 0 0 2px rgba(227, 82, 5, 0.3);
+}


### PR DESCRIPTION
## Description

Fixed the inconsistency in the Contact Us page where the form boxes (input fields, textarea, etc.) remained in light mode even after switching to Dark Mode. Updated the styles so that all form elements now properly adapt to dark mode, improving readability and ensuring a consistent user experience.

Fixes: #352 

## Type of Change

- [ ] Profile Added
- [ ] Project Added
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify):

## How to Test

- Navigate to the Contact Us page.
- Toggle the Dark Mode switch.
- Verify that all form fields (inputs, textarea, select, etc.) now display in dark mode.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [ ] I have added tests to cover my changes (if applicable).
- [x] All new and existing tests pass.

## Additional Notes

This fix only updates the styling for dark mode on form elements.

## Screenshot
<img width="1919" height="903" alt="image" src="https://github.com/user-attachments/assets/8422f289-fc40-43f5-9df9-e0dd38b59559" />

